### PR TITLE
Fixed the BarcodeImage.clone() class.

### DIFF
--- a/src/BarcodeImage.java
+++ b/src/BarcodeImage.java
@@ -150,29 +150,19 @@ public class BarcodeImage implements Cloneable
    }
    
    //Implements the clonable interface
-   public BarcodeImage clone()
+   public BarcodeImage clone() throws CloneNotSupportedException
    {
-      try
-      {
-         //Clone BarcodeImage object
-         BarcodeImage copy = (BarcodeImage)super.clone();
+      //Clone BarcodeImage object
+      BarcodeImage copy = (BarcodeImage)super.clone();
          
-         //Clone each row of imageData 2d boolean array to copy
-         copy.imageData = new boolean[MAX_HEIGHT][];
-         for(int row = 0; row < MAX_HEIGHT; row++)
-         {
-            copy.imageData[row] = imageData[row].clone();
-         }
-         
-         return copy;
-      } 
-      //If cloning is not supported, return null BarcodeImage object.
-      catch (CloneNotSupportedException e)
+      //Clone each row of imageData 2d boolean array to copy
+      copy.imageData = new boolean[MAX_HEIGHT][];
+      for(int row = 0; row < MAX_HEIGHT; row++)
       {
-         BarcodeImage failedCopy = null;
-         return failedCopy;
+         copy.imageData[row] = imageData[row].clone();
       }
-      
+         
+      return copy;
    }
    
 }

--- a/src/testBarcodeImage.java
+++ b/src/testBarcodeImage.java
@@ -81,7 +81,15 @@ public class testBarcodeImage
       testFour.displayToConsole();
       
       //Test Clonable
-      BarcodeImage cloneImage = testOne.clone();
+      BarcodeImage cloneImage;
+      try
+      {
+         cloneImage = testOne.clone();
+      } catch (CloneNotSupportedException e)
+      {
+         // TODO Auto-generated catch block
+         cloneImage = new BarcodeImage();
+      }
       //Change clone by adding extra line at the bottom of the one.
       //This shows that it actually made a deep copy.
       for(int i = 0; i < 10; i++)


### PR DESCRIPTION
BarcodeImage.clone() now throws a CloneNotSupportedException if cloning
does not work for some reason. User of the class must handle this
exception or throw it. This is a small fix so that this class follows the spec.