### PR TITLE
Changed BarcodeImage.clone() to return Object.

### DIFF
--- a/src/BarcodeImage.java
+++ b/src/BarcodeImage.java
@@ -152,18 +152,19 @@ public class BarcodeImage implements Cloneable
    }
    
    //Implements the clonable interface
-   public BarcodeImage clone() throws CloneNotSupportedException
+   public Object clone() throws CloneNotSupportedException
    {
       //Clone BarcodeImage object
-      BarcodeImage copy = (BarcodeImage)super.clone();
-         
-      //Clone each row of imageData 2d boolean array to copy
+      BarcodeImage copy = (BarcodeImage) super.clone();
+      
+      
+      //Clone each row of imageData 2d boolean array to create a deep copy.
       copy.imageData = new boolean[MAX_HEIGHT][];
       for(int row = 0; row < MAX_HEIGHT; row++)
       {
          copy.imageData[row] = imageData[row].clone();
       }
-         
+      
       return copy;
    }
    

--- a/src/testBarcodeImage.java
+++ b/src/testBarcodeImage.java
@@ -84,13 +84,14 @@ public class testBarcodeImage
       BarcodeImage cloneImage;
       try
       {
-         cloneImage = testOne.clone();
+         cloneImage = (BarcodeImage) testOne.clone();
       } catch (CloneNotSupportedException e)
       {
          // TODO Auto-generated catch block
          cloneImage = new BarcodeImage();
       }
       //Change clone by adding extra line at the bottom of the one.
+      //The original and the clone BarcodeImage objects should now be different.
       //This shows that it actually made a deep copy.
       for(int i = 0; i < 10; i++)
       {


### PR DESCRIPTION
This is to fulfill the spec where clone() should return Object instead
of BarcodeImage. This means that the clone has to be cast to a
BarcodeImage object.